### PR TITLE
Require at least Django 1.8.5

### DIFF
--- a/{{cookiecutter.repo_name}}/requirements/base.txt
+++ b/{{cookiecutter.repo_name}}/requirements/base.txt
@@ -1,4 +1,4 @@
-django>=1.8.4,<1.9
+django>=1.8.5,<1.9
 django-extensions==1.5.5
 django-waffle
 djangorestframework


### PR DESCRIPTION
Now that 1.8.5 is out, we should encourage new projects to start there, not at 1.8.4.

@clintonb @bderusha @peter-fogg @jimabramson
