### PR TITLE
Upgrade the minimum required Django version to 1.8.6

### DIFF
--- a/{{cookiecutter.repo_name}}/requirements/base.txt
+++ b/{{cookiecutter.repo_name}}/requirements/base.txt
@@ -1,4 +1,4 @@
-django>=1.8.5,<1.9
+django>=1.8.6,<1.9
 django-extensions==1.5.5
 django-waffle
 djangorestframework


### PR DESCRIPTION
[Release notes](https://docs.djangoproject.com/en/1.8/releases/1.8.6/)

@edx/ecommerce 
