### PR TITLE
add reserved keyword linter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ test: clean
 	virtualenv -p python3.6 repo_name/.venv
 
 	# Generate requirement pins, install them, and execute the project's tests
-	. repo_name/.venv/bin/activate && cd repo_name && make upgrade validation_requirements
+	. repo_name/.venv/bin/activate && cd repo_name && pip install -U pip==19.3.1 wheel && make upgrade validation_requirements
 	. repo_name/.venv/bin/activate && cd repo_name && python manage.py makemigrations
 	. repo_name/.venv/bin/activate && cd repo_name && make migrate validate
 

--- a/{{cookiecutter.repo_name}}/Makefile
+++ b/{{cookiecutter.repo_name}}/Makefile
@@ -6,7 +6,7 @@
         migrate html_coverage upgrade extract_translation dummy_translations \
         compile_translations fake_translations  pull_translations \
         push_translations start-devstack open-devstack  pkg-devstack \
-        detect_changed_source_translations validate_translations
+        detect_changed_source_translations validate_translations check_keywords
 
 define BROWSER_PYSCRIPT
 import os, webbrowser, sys
@@ -82,7 +82,10 @@ pii_check: ## check for PII annotations on all Django models
 	DJANGO_SETTINGS_MODULE={{cookiecutter.repo_name}}.settings.test \
 	code_annotations django_find_annotations --config_file .pii_annotations.yml --lint --report --coverage
 
-validate: test quality pii_check ## run tests, quality, and PII annotation checks
+check_keywords: ## Scan the Django models in all installed apps in this project for restricted field names
+	python manage.py check_reserved_keywords --override_file db_keyword_overrides.yml
+
+validate: test quality pii_check check_keywords ## run tests, quality, and PII annotation checks
 
 migrate: ## apply database migrations
 	python manage.py migrate

--- a/{{cookiecutter.repo_name}}/db_keyword_overrides.yml
+++ b/{{cookiecutter.repo_name}}/db_keyword_overrides.yml
@@ -1,0 +1,13 @@
+# This file is used by the 'check_reserved_keywords' management command to allow specific field names to be overridden
+# when checking for conflicts with lists of restricted keywords used in various database/data warehouse tools.
+# For more information, see: 
+# https://openedx.atlassian.net/wiki/spaces/DE/pages/1411809288/Reserved+Keyword+Linter
+# and
+# https://github.com/edx/edx-django-release-util/release_util/management/commands/check_reserved_keywords.py
+#
+# overrides should be added in the following format:
+#   - ModelName.field_name
+---
+MYSQL:
+SNOWFLAKE:
+STITCH:

--- a/{{cookiecutter.repo_name}}/requirements/base.in
+++ b/{{cookiecutter.repo_name}}/requirements/base.in
@@ -8,6 +8,7 @@ django-waffle
 djangorestframework
 edx-auth-backends
 edx-django-utils
+edx-django-release-util
 edx-drf-extensions
 edx-rest-api-client==1.9.2
 pytz

--- a/{{cookiecutter.repo_name}}/requirements/pip-tools.in
+++ b/{{cookiecutter.repo_name}}/requirements/pip-tools.in
@@ -1,3 +1,3 @@
 # Just the dependencies to run pip-tools, mainly for the "upgrade" make target
 
-pip-tools                 # Contains pip-compile, used to generate pip requirements files
+pip-tools<5.0.0            # Contains pip-compile, used to generate pip requirements files

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/settings/base.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/settings/base.py
@@ -27,7 +27,8 @@ INSTALLED_APPS = (
     'django.contrib.contenttypes',
     'django.contrib.sessions',
     'django.contrib.messages',
-    'django.contrib.staticfiles'
+    'django.contrib.staticfiles',
+    'release_util',
 )
 
 THIRD_PARTY_APPS = (


### PR DESCRIPTION
This will include the reserved keyword linter in all new IDAs. They will get a default override file, a make target (`make check_keywords`) and it will be part of their travis CI workflow.

There was a recent release of pip-tools that requires a version of pip that we are currently not using in various edx repos. To keep things consistent, I have pinned the version of pip-tools and am explicitly keeping an older version of pip when running tests in travis.

I also organized the wiki pages concerning this work and added a new page here: https://openedx.atlassian.net/wiki/spaces/DE/pages/1411809288/Reserved+Keyword+Linter